### PR TITLE
Fix/typos and link

### DIFF
--- a/build-options.md
+++ b/build-options.md
@@ -187,7 +187,7 @@ _Deprecated._
 
 _Introduced in 7.4.0 removed in 7.13.0_
 
-Keycloakify no analyze your code and see what field name are actally used.  \
+Keycloakify now analyzes your code and see what field name are actually used.  \
 Just make sure your fieldNames aren't generated at runtime. Eg: &#x20;
 
 ```tsx

--- a/context-persistence.md
+++ b/context-persistence.md
@@ -5,7 +5,7 @@ Let's explore how we can pass query params to the URL before redirecting to the 
 It's up to you to implement it however you want but here's a solution off the shelf for you to use
 
 {% embed url="https://github.com/codegouvfr/keycloakify-starter/blob/main/src/keycloak-theme/login/valuesTransferredOverUrl.ts" %}
-Declare the varialbes that we want to pass over, here foo and bar
+Declare the variables that we want to pass over, here foo and bar
 {% endembed %}
 
 {% embed url="https://github.com/codegouvfr/keycloakify-starter/blob/cb5844c62381efed7b303886cbe460c055a62c21/src/App/App.tsx#L21-L27" %}

--- a/how-it-works.md
+++ b/how-it-works.md
@@ -1,3 +1,3 @@
 # 🤔 How it works
 
-If you would like to gain a deeper understanding of how Keycloakify operates internally, please refer to [this GitHub discussion](https://github.com/keycloakify/keycloakify/discussions/346).
+If you would like to gain a deeper understanding of how Keycloakify operates internally, please refer to [this GitHub discussion](https://github.com/keycloakify/keycloakify/discussions/346#discussioncomment-5889791).


### PR DESCRIPTION
Bonjour,

While reading the doc I found a few minor typos, so I figured I could fix them.

I also read the "How it works" discussion and I had to read the whole discussion to understand how it actually work. 
However, the most relevant part is the last comment. 
So IMO the link should redirect to this comment directly.

Cheers.