### PR TITLE
Fix bash command when initializing keycloakify project

### DIFF
--- a/keycloakify-in-my-codebase/as-a-subproject-of-your-monorepo/package-manager-workspaces.md
+++ b/keycloakify-in-my-codebase/as-a-subproject-of-your-monorepo/package-manager-workspaces.md
@@ -32,7 +32,7 @@ cd my-monorepo
 git clone https://github.com/keycloakify/keycloakify-starter apps/keycloak-theme
 rm -rf apps/keycloak-theme/.git
 rm -rf apps/keycloak-theme/.github
-rm apps/keycloak-theme/.yarn.lock
+rm apps/keycloak-theme/yarn.lock
 ```
 
 <figure><img src="../../.gitbook/assets/image (116).png" alt="" width="375"><figcaption></figcaption></figure>


### PR DESCRIPTION
In the bash command section, the remove yarn.lock file should be 

```bash
rm apps/keycloak-theme/yarn.lock
```

However the command is trying to delete `.yarn.lock` file. I assume this was a previous file made as hidden, but from the keycloakify-starter project, the `yarn.lock` file is not hidden.