### PR TITLE
Update bitnami keycloak helm chart 24.0.5 an up instruction

### DIFF
--- a/importing-your-theme-in-keycloak.md
+++ b/importing-your-theme-in-keycloak.md
@@ -167,7 +167,7 @@ dependencies:
 ```
 {% endcode %}
 
-Here we only list the rellevent values:
+Here we only list the relevant values:
 
 <pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">keycloak:
   initContainers: |
@@ -193,6 +193,35 @@ Here we only list the rellevent values:
   extraVolumes: |
     - name: extensions
       emptyDir: {}
+</code></pre>
+
+If you are using [Bitnami's Keycloak Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak) version **24.0.5** and up, you have to mount /emptydir/app-providers-dir. Detail at [How to add custom provider](https://github.com/bitnami/charts/issues/15930#issuecomment-2478437680)
+
+<pre class="language-yaml" data-title="values.yaml"><code class="lang-yaml">keycloak:
+  initContainers: |
+    - name: keycloak-plugin
+      image: curlimages/curl
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+      args:
+        - -c
+        - |
+<strong>          # Replace USER and PROJECT.    
+</strong><strong>          curl -L -f -S -o /extensions/keycloakify-starter.jar https://github.com/USER/PROJECT/releases/latest/download/keycloak-theme-for-kc-24.jar
+</strong>
+      volumeMounts:
+        - name: empty-dir
+          mountPath: /emptydir
+
+  extraVolumeMounts:
+    - mountPath: /opt/bitnami/keycloak/providers
+      name: empty-dir
+      subPath: app-providers-dir
+    
+  extraVolumes:
+    - emptyDir: {}
+      name: empty-dir
 </code></pre>
 
 Read [this section of the starter project readme](https://github.com/keycloakify/keycloakify-starter?tab=readme-ov-file#github-actions) to learn how to get GitHub Action to publish your theme's JAR as assets of your GitHub release.


### PR DESCRIPTION
Related to #25 

For bitnami keycloak helm chart 24.0.5 and up, to mount custom provider, you have to mount at `/emptydir/app-providers-dir`, more info at [How to add custom provider](https://github.com/bitnami/charts/issues/15930#issuecomment-2478437680)

I have successfully tested this with bitnami keycloak helm chart version ranging from 24.0.5 -> 24.2.0 (latest version at the written time).
If you mount directly to `/opt/bitnami/keycloak/providers`, the jar will not be copied over.

I have made some changes to the docs.

And many many thanks for this great project, super appreciated 🙏