### PR TITLE
Update v10-greater-than-v11.md

### DIFF
--- a/faq-and-help/migration-guides/v10-greater-than-v11.md
+++ b/faq-and-help/migration-guides/v10-greater-than-v11.md
@@ -292,3 +292,10 @@ This change is only required for Webpack users. Not Vite users. &#x20;
 ```
 {% endcode %}
 
+## Keys in keycloakVersionTargets have been updated
+
+{% hint style="warning" %}
+This change is only required for users of version 10.1.4 and below who use the keycloakVersionTargets configuration. &#x20;
+{% endhint %}
+
+You can get help updating your keycloakVersionTargets configuration through [targeting-specific-keycloak-versions](https://docs.keycloakify.dev/targeting-specific-keycloak-versions).


### PR DESCRIPTION
When using keycloakify v10, I customized the theme-jar using the keycloakVersionTargets configuration. However, after upgrading to v11, I encountered the following error:

- Failed at: #if !object[key]?? [in template "login.ftl" in function "toJsDeclarationString" at line 253, column 17]
- Reached through: ${toJsDeclarationString(.data_model, ... [in template "login.ftl" at line 20, column 19]

I then discovered that the error was caused by a misconfiguration of keycloakVersionTargets. Therefore, I believe it is necessary to include this information in the upgrade announcement.