### PR TITLE
fix: use empty-dir volume to mount theme

### DIFF
--- a/deploying-your-theme.md
+++ b/deploying-your-theme.md
@@ -165,29 +165,27 @@ Here we only list the relevant values:
 
 {% code title="values.yaml" %}
 ```yaml
-keycloak:
+# OPTIONAL: Here you can define environment variables that you can access in your theme, see: https://docs.keycloakify.dev/features/environment-variables
+extraEnvVars:
+  - name: MY_APP_PALLET
+    value: "monokai"
 
-  # OPTIONAL: Here you can define env var that you can access in your theme, see: https://docs.keycloakify.dev/features/environment-variables
-  extraEnvVars:
-    - name: MY_APP_PALLET
-      value: "monokai"
+initContainers:
+  - name: realm-ext-provider
+    image: curlimages/curl
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+    args:
+      - -c
+      - |
+        # Replace USER and PROJECT, use the correct version of the jar for the keycloak version you are deploying
+        mkdir -p /emptydir/app-providers-dir
+        curl -L -f -S -o /emptydir/app-providers-dir/keycloak-theme.jar https://github.com/USER/PROJECT/releases/download/VERSION/keycloak-theme-for-kc-all-other-versions.jar
 
-  initContainers:
-    - name: realm-ext-provider
-      image: curlimages/curl
-      imagePullPolicy: IfNotPresent
-      command:
-        - sh
-      args:
-        - -c
-        - |
-          # Replace USER and PROJECT, use the correct version of the jar for the keycloak version you are deploying
-          mkdir -p /emptydir/app-providers-dir
-          curl -L -f -S -o /emptydir/app-providers-dir/keycloak-theme.jar https://github.com/USER/PROJECT/releases/download/VERSION/keycloak-theme-for-kc-all-other-versions.jar
-
-      volumeMounts:
-        - name: empty-dir
-          mountPath: /emptydir
+    volumeMounts:
+      - name: empty-dir
+        mountPath: /emptydir
 ```
 {% endcode %}
 

--- a/deploying-your-theme.md
+++ b/deploying-your-theme.md
@@ -118,7 +118,7 @@ services:
       KC_HEALTH_ENABLED: true
       KC_HOSTNAME_STRICT_HTTPS: false
       KC_HOSTNAME_STRICT: false
-      
+
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
       KC_DB: postgres
@@ -127,7 +127,7 @@ services:
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - 8080:8080
-    volumes: 
+    volumes:
       - ./themes:/opt/keycloak/providers/
     restart: unless-stopped
     depends_on:
@@ -156,7 +156,7 @@ name: keycloak
 version: 1.0.0
 dependencies:
   - name: keycloak
-    version: 24.4.4 # Keycloak 26.1.0
+    version: 24.4.10 # Keycloak 26.1.2
     repository: oci://registry-1.docker.io/bitnamicharts
 ```
 {% endcode %}
@@ -181,24 +181,13 @@ keycloak:
       args:
         - -c
         - |
-          # Replace USER and PROJECT, use the correct version of the jar for the keycloak version you are deploying    
-          curl -L -f -S -o /extensions/keycloak-theme.jar https://github.com/USER/PROJECT/releases/download/VERSION/keycloak-theme-for-kc-all-other-versions.jar
+          # Replace USER and PROJECT, use the correct version of the jar for the keycloak version you are deploying
+          mkdir -p /emptydir/app-providers-dir
+          curl -L -f -S -o /emptydir/app-providers-dir/keycloak-theme.jar https://github.com/USER/PROJECT/releases/download/VERSION/keycloak-theme-for-kc-all-other-versions.jar
 
-      volumeMounts:
-        - name: extensions
-          mountPath: /extensions
-
-  extraVolumeMounts:
-    - name: extensions
-      mountPath: /opt/bitnami/keycloak/providers
-
-  extraVolumes:
-    - name: extensions
-      emptyDir: {}
       volumeMounts:
         - name: empty-dir
-          mountPath: /extensions
-          subPath: app-providers-dir
+          mountPath: /emptydir
 ```
 {% endcode %}
 


### PR DESCRIPTION
The values provided in this example does not work with the latest versions of the helm chart. This is because the bitnami keycloak chart mounts its own volume at `/opt/bitnami/keycloak/providers`.

The solution is to mount [the `empty-dir` volume](https://github.com/bitnami/charts/blob/8213f749a83b78d692fd5728ba7df54cdd17e25e/bitnami/keycloak/templates/statefulset.yaml#L339-L341) into the init container and move the theme into `/app-providers-dir`, which is then [mounted into the main keycloak container](https://github.com/bitnami/charts/blob/8213f749a83b78d692fd5728ba7df54cdd17e25e/bitnami/keycloak/templates/statefulset.yaml#L306-L308) at `/opt/bitnami/keycloak/providers`. See [the configuration used](https://github.com/bitnami/charts/blob/8213f749a83b78d692fd5728ba7df54cdd17e25e/bitnami/keycloak/templates/statefulset.yaml#L121-L123) for [the `prepare-write-dirs` init container](https://github.com/bitnami/charts/blob/8213f749a83b78d692fd5728ba7df54cdd17e25e/bitnami/keycloak/templates/statefulset.yaml#L111) in the bitnami chart for example.

Simple way to test this out:

```
$ cat values.yaml
initContainers:
- name: keycloak-theme-provider
  image: my-keycloak-theme:latest
  imagePullPolicy: Always
  command:
    - sh
  args:
    - -c
    - |
      echo "Copying theme..."
      mkdir -p /emptydir/app-providers-dir
      cp -R /themes/keycloak-theme-for-kc-all-other-versions.jar /emptydir/app-providers-dir/keycloak-theme-for-kc-all-other-versions.jar
      echo "Done copying theme."
  volumeMounts:
    - name: empty-dir
      mountPath: /emptydir
```

Then, using [`k3d`](https://k3d.io/):

```
$ k3d cluster create keycloakify-test
$ helm install keycloak oci://registry-1.docker.io/bitnamicharts/keycloak -f values.yaml
```

I'm not sure the `mkdir -p app-providers-dir` is totally necessary, but I thought it wouldn't hurt to add it in there for added insurance.