### PR TITLE
Fix broken React example link in email-theme.md

### DIFF
--- a/theme-types/email-theme.md
+++ b/theme-types/email-theme.md
@@ -21,7 +21,7 @@ This approach only works in Vite project. So not with Webpack/Create-React-App
 {% tabs %}
 {% tab title="React" %}
 For react, there is a working example in the /example directory of keycloakify-emails that uses jsx-email\
-[https://github.com/garronej/keycloakify-emails/tree/main/example](https://github.com/garronej/keycloakify-emails/tree/main/example)
+[https://github.com/timofei-iatsenko/keycloakify-emails](https://github.com/timofei-iatsenko/keycloakify-emails)
 {% endtab %}
 
 {% tab title="Svelte" %}

--- a/theme-types/email-theme.md
+++ b/theme-types/email-theme.md
@@ -21,7 +21,7 @@ This approach only works in Vite project. So not with Webpack/Create-React-App
 {% tabs %}
 {% tab title="React" %}
 For react, there is a working example in the /example directory of keycloakify-emails that uses jsx-email\
-[https://github.com/timofei-iatsenko/keycloakify-emails](https://github.com/timofei-iatsenko/keycloakify-emails)
+[https://github.com/timofei-iatsenko/keycloakify-emails](https://github.com/timofei-iatsenko/keycloakify-emails/tree/main/example)
 {% endtab %}
 
 {% tab title="Svelte" %}

--- a/theme-types/email-theme.md
+++ b/theme-types/email-theme.md
@@ -21,7 +21,7 @@ This approach only works in Vite project. So not with Webpack/Create-React-App
 {% tabs %}
 {% tab title="React" %}
 For react, there is a working example in the /example directory of keycloakify-emails that uses jsx-email\
-[https://github.com/garronej/keycloakify-emails/tree/dir\_location\_new/example](https://github.com/garronej/keycloakify-emails/tree/dir_location_new/example)
+[https://github.com/garronej/keycloakify-emails/tree/main/example](https://github.com/garronej/keycloakify-emails/tree/main/example)
 {% endtab %}
 
 {% tab title="Svelte" %}


### PR DESCRIPTION
update link to react keycloakify email example.

The old link was not working and resolved to a 404 github page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the example URL in the theme documentation to point to the repository root (main branch) instead of the outdated feature branch, ensuring the React example links to the current, accessible resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->